### PR TITLE
changed the label for the ad slots field

### DIFF
--- a/php/ad-servers/class-ad-layers-dfp.php
+++ b/php/ad-servers/class-ad-layers-dfp.php
@@ -211,9 +211,9 @@ class Ad_Layers_DFP extends Ad_Layers_Ad_Server {
 					'ad_units' => new Fieldmanager_Group( array(
 						'limit' => 0,
 						'extra_elements' => 0,
-						'label' => __( 'Ad Units', 'ad-layers' ),
-						'label_macro' => array( __( 'Ad Unit: %s', 'ad-layers' ), 'code' ),
-						'add_more_label' => __( 'Add Ad Unit', 'ad-layers' ),
+						'label' => __( 'Ad Slots', 'ad-layers' ),
+						'label_macro' => array( __( 'Ad Slot: %s', 'ad-layers' ), 'code' ),
+						'add_more_label' => __( 'Add Ad Slot', 'ad-layers' ),
 						'collapsible' => true,
 						'collapsed' => true,
 						'children' => array(


### PR DESCRIPTION
I changed the label from 'Ad Units' to 'Ad Slots' to match DFP terminology. It now also matches the terminology used on the Ad Layers admin panel page.
