### PR TITLE
Ad Units in Post Columns

### DIFF
--- a/php/class-ad-layers-post-type.php
+++ b/php/class-ad-layers-post-type.php
@@ -106,7 +106,7 @@ if ( ! class_exists( 'Ad_Layers_Post_Type' ) ) :
 					$value = get_post_meta( $post_id, $column, true );
 					if ( ! empty( $value ) ) {
 						if ( is_array( $value ) ) {
-							$value = implode( ', ', $value );
+							$value = implode( ', ', array_map( function ( $value ) { return $value['ad_unit']; }, $value ));
 						}
 						echo esc_html( $value );
 					}

--- a/php/class-ad-layers-post-type.php
+++ b/php/class-ad-layers-post-type.php
@@ -106,7 +106,7 @@ if ( ! class_exists( 'Ad_Layers_Post_Type' ) ) :
 					$value = get_post_meta( $post_id, $column, true );
 					if ( ! empty( $value ) ) {
 						if ( is_array( $value ) ) {
-							$value = implode( ', ', array_map( function ( $value ) { return $value['ad_unit']; }, $value ));
+							$value = implode( ', ', array_map( function ( $value ) { return $value['ad_unit']; }, $value ) );
 						}
 						echo esc_html( $value );
 					}


### PR DESCRIPTION
the Ad Units column was displaying a comma delimited list of "array" rather than outputting the actual ad_unit name. This adjusts to output the name