### PR TITLE
Fixes to how the 'ad_layers' WP option gets saved when an Ad Layer is…

### DIFF
--- a/php/class-ad-layers-post-type.php
+++ b/php/class-ad-layers-post-type.php
@@ -281,7 +281,7 @@ if ( ! class_exists( 'Ad_Layers_Post_Type' ) ) :
 
 			$ad_layers[ $position ] = $new_layer;
 
-			update_option( 'ad_layers', apply_filters( 'ad_layers_save_post', $ad_layers ) );
+			update_option( 'ad_layers', apply_filters( 'ad_layers_save_post', array_values( $ad_layers ) ) );
 		}
 
 		/**
@@ -306,7 +306,7 @@ if ( ! class_exists( 'Ad_Layers_Post_Type' ) ) :
 				}
 			}
 
-			update_option( 'ad_layers', apply_filters( 'ad_layers_delete_post', $ad_layers ) );
+			update_option( 'ad_layers', apply_filters( 'ad_layers_delete_post', array_values( $ad_layers ) ) );
 		}
 	}
 


### PR DESCRIPTION
… updated, deleted, or restored from Trash. Also, added code to detect and remove orphaned Ad Layer Posts from the 'ad_layer' WP option array prior to any time it gets updated.