### PR TITLE
Ensure that ads are displayed even if JS API isn't available.

### DIFF
--- a/php/ad-servers/class-ad-layers-dfp.php
+++ b/php/ad-servers/class-ad-layers-dfp.php
@@ -242,7 +242,7 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 				do_action( 'ad_layers_dfp_custom_targeting' );
 				?>
 
-				if ( ! AdLayersAPI.isDebug() ) {
+				if ( typeof AdLayersAPI === 'undefined' || ! AdLayersAPI.isDebug() ) {
 					googletag.enableServices();
 				}
 			});


### PR DESCRIPTION
This way, developers who aren't using the JavaScript API can deregister the scripts, and ads will still display fine.

We're not using the JavaScript API, so in a separate plugin we're dequeueing the scripts and styles:
```php
wp_dequeue_script( 'ad-layers' );
wp_dequeue_style( 'ad-layers' );
wp_dequeue_script( 'ad-layers-dfp' );
wp_dequeue_style( 'ad-layers-dfp' );
```
Thank you for looking into this pull request! :smile: