### PR TITLE
Force scripts to load in the header for early ad loading

### DIFF
--- a/php/ad-servers/class-ad-layers-ad-server.php
+++ b/php/ad-servers/class-ad-layers-ad-server.php
@@ -149,8 +149,8 @@ if ( ! class_exists( 'Ad_Layers_Ad_Server' ) ) :
 				$js_api_class = $this->js_api_class;
 			}
 
-			// Load the base Javascript library
-			wp_enqueue_script( $this->handle, AD_LAYERS_ASSETS_DIR . 'js/ad-layers.js', $dependencies, AD_LAYERS_GLOBAL_ASSET_VERSION, true );
+			// Load the base Javascript library (in header to ensure early ad loading)
+			wp_enqueue_script( $this->handle, AD_LAYERS_ASSETS_DIR . 'js/ad-layers.js', $dependencies, AD_LAYERS_GLOBAL_ASSET_VERSION, false );
 
 			// Load the CSS. Mostly used in debug mode.
 			wp_enqueue_style( $this->handle, AD_LAYERS_ASSETS_DIR . 'css/ad-layers.css', array(), AD_LAYERS_GLOBAL_ASSET_VERSION );

--- a/php/ad-servers/class-ad-layers-dfp.php
+++ b/php/ad-servers/class-ad-layers-dfp.php
@@ -146,8 +146,8 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 		 * @access public
 		 */
 		public function enqueue_scripts() {
-			// Load the base Javascript library
-			wp_enqueue_script( $this->handle, AD_LAYERS_ASSETS_DIR . 'js/ad-layers-dfp.js', array( 'jquery' ), AD_LAYERS_GLOBAL_ASSET_VERSION, true );
+			// Load the base Javascript library (in header to ensure early ad loading)
+			wp_enqueue_script( $this->handle, AD_LAYERS_ASSETS_DIR . 'js/ad-layers-dfp.js', array( 'jquery' ), AD_LAYERS_GLOBAL_ASSET_VERSION, false );
 
 			// Load the CSS. Mostly used in debug mode.
 			wp_enqueue_style( $this->handle, AD_LAYERS_ASSETS_DIR . 'css/ad-layers-dfp.css', array(), AD_LAYERS_GLOBAL_ASSET_VERSION );


### PR DESCRIPTION
This actually undoes PR https://github.com/alleyinteractive/ad-layers/pull/29 because loading these scripts in the footer causes performance issues. The ad scripts need to be loaded in the header so that we can get the ad responses as soon as possible.