### PR TITLE
Fix bugs with layer matching and static path templates

### DIFF
--- a/php/ad-servers/class-ad-layers-dfp.php
+++ b/php/ad-servers/class-ad-layers-dfp.php
@@ -866,7 +866,7 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 			// The default path template should always just be the account ID and domain
 			$account_id = $this->get_setting( 'account_id' );
 			$domain = $this->get_domain();
-			$path = '/' . $account_id . '/' . $domain;
+			$path_template = '/' . $account_id . '/' . $domain;
 
 			if ( ! empty( $ad_unit ) && ! empty( $this->ad_unit_paths[ $ad_unit ] ) ) {
 				$path_template = $this->ad_unit_paths[ $ad_unit ];
@@ -885,11 +885,12 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 			}
 
 			if ( ! empty( $path_template ) ) {
+				$replacements = array();
+
 				// Handle any formatting tags
 				preg_match_all( apply_filters( 'ad_layers_dfp_formatting_tag_pattern', $this->formatting_tag_pattern ), $path_template, $matches );
 				if ( ! empty( $matches[0] ) ) {
 					// Build a list of found tags for replacement
-					$replacements = array();
 					$unique_matches = array_unique( $matches[0] );
 
 					// Iterate over and replace each
@@ -948,12 +949,10 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 							}
 						}
 					}
-
-					// Do the replacements and create the final path
-					if ( ! empty( $replacements ) ) {
-						$path = str_replace( array_keys( $replacements ), array_values( $replacements ), $path_template );
-					}
 				}
+
+				// Do the replacements and create the final path
+				$path = str_replace( array_keys( $replacements ), array_values( $replacements ), $path_template );
 			}
 
 			// Finally, the path should never end in a trailing slash.

--- a/php/class-ad-layers.php
+++ b/php/class-ad-layers.php
@@ -281,6 +281,7 @@ if ( ! class_exists( 'Ad_Layers' ) ) :
 					} else {
 						// if there is no taxonomy data, this is a page type match
 						$this->ad_layer = $ad_layer;
+						break;
 					}
 				} else if ( is_post_type_archive()
 					&& empty( $taxonomies )
@@ -289,7 +290,7 @@ if ( ! class_exists( 'Ad_Layers' ) ) :
 						( ! empty( $post_types ) && in_array( $queried_object->name, $post_types ) )
 						|| empty( $post_types )
 					)
-					&& ( empty( $page_types ) || in_array( $queried_object->name, $page_types ) ) ) {
+					&& ( empty( $page_types ) || in_array( 'archive::' . $queried_object->name, $page_types ) ) ) {
 					$this->ad_layer = $ad_layer;
 					break;
 				} else if ( is_author()

--- a/php/class-ad-layers.php
+++ b/php/class-ad-layers.php
@@ -219,7 +219,7 @@ if ( ! class_exists( 'Ad_Layers' ) ) :
 
 				if ( is_singular() ) {
 					// See if a specific ad layer is set
-					$ad_layer_id = get_post_meta( get_the_ID(), 'ad_layer', true );
+					$ad_layer_id = intval( get_post_meta( get_the_ID(), 'ad_layer', true ) );
 					if ( ! empty( $ad_layer_id ) ) {
 						$this->ad_layer = array(
 							'post_id' => $ad_layer_id,

--- a/php/class-ad-layers.php
+++ b/php/class-ad-layers.php
@@ -353,7 +353,7 @@ if ( ! class_exists( 'Ad_Layers' ) ) :
 				$archived_post_types = apply_filters( 'ad_layers_ad_server_archived_post_types', wp_list_filter( get_post_types( array( 'has_archive' => true ), 'objects' ), array( 'label' => false ), 'NOT' ) );
 				if ( ! empty( $archived_post_types ) ) {
 					foreach ( $archived_post_types as $post_type ) {
-						$page_types[ $post_type->name ] = $post_type->label . __( ' Archive', 'ad-layers' );
+						$page_types[ 'archive::' . $post_type->name ] = $post_type->label . __( ' Archive', 'ad-layers' );
 					}
 				}
 
@@ -396,6 +396,7 @@ if ( ! class_exists( 'Ad_Layers' ) ) :
 					( function_exists( 'is_' . $key ) && true === call_user_func( 'is_' . $key ) )
 					|| ( 'post_tag' == $key && is_tag() )
 					|| ( 'notfound' == $key && is_404() )
+					|| ( 'archive::' == substr( $key, 0, 9 ) && is_post_type_archive( substr( $key, 9 ) ) )
 					|| ( post_type_exists( $key ) && is_singular( $key ) )
 					|| ( taxonomy_exists( $key ) && is_tax( $key ) )
 				) {

--- a/php/class-ad-layers.php
+++ b/php/class-ad-layers.php
@@ -262,7 +262,7 @@ if ( ! class_exists( 'Ad_Layers' ) ) :
 					&& ( empty( $page_types ) || in_array( 'home', $page_types ) ) ) {
 					$this->ad_layer = $ad_layer;
 					break;
-				} else if ( ( is_tax() || is_category() || is_tag() )
+				} elseif ( ( is_tax() || is_category() || is_tag() )
 					&& empty( $post_types )
 					&& ( empty( $page_types ) || in_array( $queried_object->taxonomy, $page_types ) ) ) {
 
@@ -283,7 +283,7 @@ if ( ! class_exists( 'Ad_Layers' ) ) :
 						$this->ad_layer = $ad_layer;
 						break;
 					}
-				} else if ( is_post_type_archive()
+				} elseif ( is_post_type_archive()
 					&& empty( $taxonomies )
 					&& empty( $taxonomy_terms )
 					&& (
@@ -293,32 +293,32 @@ if ( ! class_exists( 'Ad_Layers' ) ) :
 					&& ( empty( $page_types ) || in_array( 'archive::' . $queried_object->name, $page_types ) ) ) {
 					$this->ad_layer = $ad_layer;
 					break;
-				} else if ( is_author()
+				} elseif ( is_author()
 					&& empty( $taxonomies )
 					&& empty( $taxonomy_terms )
 					&& empty( $post_types )
-					&& ( empty( $page_types ) || in_array( 'author', $page_types ) ) ) {
+					&& in_array( 'author', $page_types ) ) {
 					$this->ad_layer = $ad_layer;
 					break;
-				} else if ( is_date()
+				} elseif ( is_date()
 					&& empty( $taxonomies )
 					&& empty( $taxonomy_terms )
 					&& empty( $post_types )
-					&& ( empty( $page_types ) || in_array( 'date', $page_types ) ) ) {
+					&& in_array( 'date', $page_types ) ) {
 					$this->ad_layer = $ad_layer;
 					break;
-				} else if ( is_404()
+				} elseif ( is_404()
 					&& empty( $taxonomies )
 					&& empty( $taxonomy_terms )
 					&& empty( $post_types )
-					&& ( empty( $page_types ) || in_array( 'notfound', $page_types ) ) ) {
+					&& in_array( 'notfound', $page_types ) ) {
 					$this->ad_layer = $ad_layer;
 					break;
-				} else if ( is_search()
+				} elseif ( is_search()
 					&& empty( $taxonomies )
 					&& empty( $taxonomy_terms )
 					&& empty( $post_types )
-					&& ( empty( $page_types ) || in_array( 'search', $page_types ) ) ) {
+					&& in_array( 'search', $page_types ) ) {
 					$this->ad_layer = $ad_layer;
 					break;
 				}

--- a/php/class-ad-layers.php
+++ b/php/class-ad-layers.php
@@ -396,15 +396,11 @@ if ( ! class_exists( 'Ad_Layers' ) ) :
 					( function_exists( 'is_' . $key ) && true === call_user_func( 'is_' . $key ) )
 					|| ( 'post_tag' == $key && is_tag() )
 					|| ( 'notfound' == $key && is_404() )
-					|| ( 'archive::' == substr( $key, 0, 9 ) && is_post_type_archive( substr( $key, 9 ) ) )
+					|| ( 'archive::' === substr( $key, 0, 9 ) && is_post_type_archive( substr( $key, 9 ) ) )
 					|| ( post_type_exists( $key ) && is_singular( $key ) )
 					|| ( taxonomy_exists( $key ) && is_tax( $key ) )
 				) {
 					$page_type = $key;
-				}
-
-				// The page type was found
-				if ( ! empty( $page_type ) ) {
 					break;
 				}
 			}

--- a/tests/php/test-active-layer.php
+++ b/tests/php/test-active-layer.php
@@ -29,7 +29,7 @@ class Ad_Layers_Active_Layer_Tests extends Ad_Layers_UnitTestCase {
 		parent::tearDown();
 	}
 
-	protected function build_and_get_layer( $args ) {
+	protected function build_and_get_layer( $args = array() ) {
 		$layer = $this->factory->post->create( array( 'post_type' => 'ad-layer' ) );
 		$args = wp_parse_args( $args, array(
 			'post_types' => array(),
@@ -236,5 +236,31 @@ class Ad_Layers_Active_Layer_Tests extends Ad_Layers_UnitTestCase {
 		$this->go_to( get_post_type_archive_link( $post_type_2 ) );
 		$this->assertTrue( is_post_type_archive( $post_type_2 ) );
 		$this->assertSame( $layer_2, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_taxonomies() {
+		$layer = $this->build_and_get_layer( array( 'taxonomies' => 'category' ) );
+
+		$this->go_to( get_category_link( $this->cat_id ) );
+		$this->assertTrue( is_category() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_terms() {
+		$layer = $this->build_and_get_layer();
+		wp_set_object_terms( $layer, $this->cat_id, 'category' );
+
+		$this->go_to( get_category_link( $this->cat_id ) );
+		$this->assertTrue( is_category() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_post_by_terms() {
+		$layer = $this->build_and_get_layer();
+		wp_set_object_terms( $layer, $this->cat_id, 'category' );
+
+		$this->go_to( get_permalink( $this->post_id ) );
+		$this->assertTrue( is_single() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
 	}
 }

--- a/tests/php/test-active-layer.php
+++ b/tests/php/test-active-layer.php
@@ -6,7 +6,7 @@ class Ad_Layers_Active_Layer_Tests extends Ad_Layers_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		register_taxonomy( 'test-taxonomy', 'post', array( 'label' => rand_str() ) );
+		register_taxonomy( 'test-taxonomy', 'post' );
 
 		$this->editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
 
@@ -167,7 +167,7 @@ class Ad_Layers_Active_Layer_Tests extends Ad_Layers_UnitTestCase {
 	public function test_active_layer_cpt_without_archive() {
 		$post_type = rand_str( 20 );
 		register_post_type( $post_type, array( 'public' => true ) );
-		$cpt_id = $this->factory->post->create( array( 'post_title' => 'hello-cpt', 'post_type' => $post_type, 'label' => rand_str() ) );
+		$cpt_id = $this->factory->post->create( array( 'post_title' => 'hello-cpt', 'post_type' => $post_type ) );
 		$layer = $this->build_and_get_layer( array( 'page_types' => $post_type ) );
 
 		$this->go_to( get_permalink( $cpt_id ) );
@@ -178,7 +178,7 @@ class Ad_Layers_Active_Layer_Tests extends Ad_Layers_UnitTestCase {
 	public function test_active_layer_cpt_with_archive() {
 		$post_type = rand_str( 20 );
 		register_post_type( $post_type, array( 'public' => true, 'has_archive' => true ) );
-		$cpt_id = $this->factory->post->create( array( 'post_title' => 'hello-cpt', 'post_type' => $post_type, 'label' => rand_str() ) );
+		$cpt_id = $this->factory->post->create( array( 'post_title' => 'hello-cpt', 'post_type' => $post_type ) );
 
 		$layer_single = $this->build_and_get_layer( array( 'page_types' => $post_type ) );
 		$layer_archive = $this->build_and_get_layer( array( 'page_types' => 'archive::' . $post_type ) );

--- a/tests/php/test-active-layer.php
+++ b/tests/php/test-active-layer.php
@@ -263,4 +263,19 @@ class Ad_Layers_Active_Layer_Tests extends Ad_Layers_UnitTestCase {
 		$this->assertTrue( is_single() );
 		$this->assertSame( $layer, $this->get_active_ad_layer() );
 	}
+
+	public function test_active_layer_post_with_layer_override() {
+		$layer_override = $this->build_and_get_layer( array( 'page_type' => 'search' ) );
+		$layer_natural = $this->build_and_get_layer( array( 'page_type' => 'post' ) );
+
+		// verify that without an override, the post matches $layer_natural
+		$this->go_to( get_permalink( $this->post_id ) );
+		$this->assertTrue( is_single() );
+		$this->assertSame( $layer_natural, $this->get_active_ad_layer() );
+		$this->assertNotSame( $layer_override, $this->get_active_ad_layer() );
+
+		// now use the post meta to override the natural match
+		add_post_meta( $this->post_id, 'ad_layer', $layer_override );
+		$this->assertSame( $layer_override, $this->get_active_ad_layer() );
+	}
 }

--- a/tests/php/test-active-layer.php
+++ b/tests/php/test-active-layer.php
@@ -193,4 +193,48 @@ class Ad_Layers_Active_Layer_Tests extends Ad_Layers_UnitTestCase {
 		$this->assertTrue( is_post_type_archive( $post_type ) );
 		$this->assertSame( $layer_archive, $this->get_active_ad_layer() );
 	}
+
+	public function test_active_layer_post_types() {
+		$layer = $this->build_and_get_layer( array( 'post_types' => 'page' ) );
+
+		// Ensure that a singular post fails
+		$this->go_to( get_permalink( $this->post_id ) );
+		$this->assertTrue( is_single() );
+		$this->assertNotSame( $layer, $this->get_active_ad_layer() );
+
+		// ... but that a singular page passes
+		$this->go_to( get_permalink( $this->page_id ) );
+		$this->assertTrue( is_page() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_post_types_by_archive() {
+		$post_type_1 = rand_str( 20 );
+		$post_type_2 = rand_str( 20 );
+		register_post_type( $post_type_1, array( 'public' => true, 'has_archive' => true ) );
+		register_post_type( $post_type_2, array( 'public' => true, 'has_archive' => true ) );
+		$cpt_1 = $this->factory->post->create( array( 'post_title' => 'hello-cpt-1', 'post_type' => $post_type_1 ) );
+		$cpt_2 = $this->factory->post->create( array( 'post_title' => 'hello-cpt-2', 'post_type' => $post_type_2 ) );
+
+		$layer_1 = $this->build_and_get_layer( array( 'post_types' => $post_type_1 ) );
+		$layer_2 = $this->build_and_get_layer( array( 'post_types' => $post_type_2 ) );
+
+		// Singular view
+		$this->go_to( get_permalink( $cpt_1 ) );
+		$this->assertTrue( is_singular( $post_type_1 ) );
+		$this->assertSame( $layer_1, $this->get_active_ad_layer() );
+
+		$this->go_to( get_permalink( $cpt_2 ) );
+		$this->assertTrue( is_singular( $post_type_2 ) );
+		$this->assertSame( $layer_2, $this->get_active_ad_layer() );
+
+		// Archive view
+		$this->go_to( get_post_type_archive_link( $post_type_1 ) );
+		$this->assertTrue( is_post_type_archive( $post_type_1 ) );
+		$this->assertSame( $layer_1, $this->get_active_ad_layer() );
+
+		$this->go_to( get_post_type_archive_link( $post_type_2 ) );
+		$this->assertTrue( is_post_type_archive( $post_type_2 ) );
+		$this->assertSame( $layer_2, $this->get_active_ad_layer() );
+	}
 }

--- a/tests/php/test-active-layer.php
+++ b/tests/php/test-active-layer.php
@@ -1,0 +1,196 @@
+<?php
+
+class Ad_Layers_Active_Layer_Tests extends Ad_Layers_UnitTestCase {
+	protected $post_id, $page_id, $cat_id, $tag_id, $tax_id, $editor_id;
+
+	public function setUp() {
+		parent::setUp();
+
+		register_taxonomy( 'test-taxonomy', 'post', array( 'label' => rand_str() ) );
+
+		$this->editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+
+		$this->cat_id = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'cat-a' ) );
+		$this->tag_id = $this->factory->term->create( array( 'taxonomy' => 'post_tag', 'name' => 'tag-b' ) );
+		$this->tax_id = $this->factory->term->create( array( 'taxonomy' => 'test-taxonomy', 'name' => 'tax-c' ) );
+
+		$this->post_id = $this->factory->post->create( array(
+			'post_title' => 'hello-world',
+			'post_author' => $this->editor_id,
+			'post_category' => array( $this->cat_id ),
+			'tax_input' => array( 'post_tag' => 'tag-b', 'test-taxonomy' => 'tax-c' ),
+			'post_date' => '2015-03-14 12:34:56',
+		) );
+		$this->page_id = $this->factory->post->create( array( 'post_title' => 'hello-page', 'post_type' => 'page' ) );
+	}
+
+	public function tearDown() {
+		self::delete_user( $this->editor_id );
+		parent::tearDown();
+	}
+
+	protected function build_and_get_layer( $args ) {
+		$layer = $this->factory->post->create( array( 'post_type' => 'ad-layer' ) );
+		$args = wp_parse_args( $args, array(
+			'post_types' => array(),
+			'page_types' => array(),
+			'taxonomies' => array(),
+		) );
+		add_post_meta( $layer, 'ad_layer_post_types', (array) $args['post_types'] );
+		add_post_meta( $layer, 'ad_layer_page_types', (array) $args['page_types'] );
+		add_post_meta( $layer, 'ad_layer_taxonomies', (array) $args['taxonomies'] );
+		return $layer;
+	}
+
+	protected function get_active_ad_layer() {
+		$layers = get_option( 'ad_layers', array() );
+		usort( $layers, function( $a, $b ) {
+			if ( $a['post_id'] == $b['post_id'] ) {
+			    return 0;
+			}
+			return ( $a['post_id'] < $b['post_id'] ) ? 1 : -1;
+		} );
+		update_option( 'ad_layers', $layers );
+		Ad_Layers::instance()->setup();
+		Ad_Layers::instance()->set_active_ad_layer();
+		$layer = Ad_Layers::instance()->ad_layer;
+		return ( ! empty( $layer['post_id'] ) ? $layer['post_id'] : false );
+	}
+
+	public function test_active_layer_failed() {
+		// Set this to something that won't match
+		$layer = $this->build_and_get_layer( array( 'page_types' => 'search' ) );
+
+		$this->go_to( '/' );
+		$this->assertTrue( is_home() );
+		$this->assertNotSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_home() {
+		$layer = $this->build_and_get_layer( array( 'page_types' => 'home' ) );
+
+		$this->go_to( '/' );
+		$this->assertTrue( is_home() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_single_post() {
+		$layer = $this->build_and_get_layer( array( 'page_types' => 'post' ) );
+
+		$this->go_to( get_permalink( $this->post_id ) );
+		$this->assertTrue( is_single() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_single_page() {
+		$layer = $this->build_and_get_layer( array( 'page_types' => 'page' ) );
+
+		$this->go_to( get_permalink( $this->page_id ) );
+		$this->assertTrue( is_page() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_category() {
+		$layer = $this->build_and_get_layer( array( 'page_types' => 'category' ) );
+
+		$this->go_to( get_category_link( $this->cat_id ) );
+		$this->assertTrue( is_category() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_tag() {
+		$layer = $this->build_and_get_layer( array( 'page_types' => 'post_tag' ) );
+
+		$this->go_to( get_tag_link( $this->tag_id ) );
+		$this->assertTrue( is_tag() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_custom_taxonomy() {
+		$layer = $this->build_and_get_layer( array( 'page_types' => 'test-taxonomy' ) );
+
+		$this->go_to( get_term_link( $this->tax_id, 'test-taxonomy' ) );
+		$this->assertTrue( is_tax() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_author() {
+		$layer = $this->build_and_get_layer( array( 'page_types' => 'author' ) );
+
+		$this->go_to( get_author_posts_url( $this->editor_id ) );
+		$this->assertTrue( is_author() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_date() {
+		$layer = $this->build_and_get_layer( array( 'page_types' => 'date' ) );
+
+		$this->go_to( get_year_link( '2015' ) );
+		$this->assertTrue( is_year() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+
+		$this->go_to( get_month_link( '2015', '03' ) );
+		$this->assertTrue( is_month() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+
+		$this->go_to( get_day_link( '2015', '03', '14' ) );
+		$this->assertTrue( is_day() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+
+		$this->go_to( '/' );
+		$this->assertNotSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_notfound() {
+		$layer = $this->build_and_get_layer( array( 'page_types' => 'notfound' ) );
+
+		$this->go_to( '?name=' . rand_str() );
+		$this->assertTrue( is_404() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+
+		$this->go_to( get_year_link( '2025' ) );
+		$this->assertTrue( is_404() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+
+		$this->go_to( '/' );
+		$this->assertNotSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_search() {
+		$layer = $this->build_and_get_layer( array( 'page_types' => 'search' ) );
+
+		$this->go_to( '?s=hello' );
+		$this->assertTrue( is_search() );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_cpt_without_archive() {
+		$post_type = rand_str( 20 );
+		register_post_type( $post_type, array( 'public' => true ) );
+		$cpt_id = $this->factory->post->create( array( 'post_title' => 'hello-cpt', 'post_type' => $post_type, 'label' => rand_str() ) );
+		$layer = $this->build_and_get_layer( array( 'page_types' => $post_type ) );
+
+		$this->go_to( get_permalink( $cpt_id ) );
+		$this->assertTrue( is_singular( $post_type ) );
+		$this->assertSame( $layer, $this->get_active_ad_layer() );
+	}
+
+	public function test_active_layer_cpt_with_archive() {
+		$post_type = rand_str( 20 );
+		register_post_type( $post_type, array( 'public' => true, 'has_archive' => true ) );
+		$cpt_id = $this->factory->post->create( array( 'post_title' => 'hello-cpt', 'post_type' => $post_type, 'label' => rand_str() ) );
+
+		$layer_single = $this->build_and_get_layer( array( 'page_types' => $post_type ) );
+		$layer_archive = $this->build_and_get_layer( array( 'page_types' => 'archive::' . $post_type ) );
+
+		// Singular view
+		$this->go_to( get_permalink( $cpt_id ) );
+		$this->assertTrue( is_singular( $post_type ) );
+		$this->assertSame( $layer_single, $this->get_active_ad_layer() );
+
+		// Archive view
+		$this->go_to( get_post_type_archive_link( $post_type ) );
+		$this->assertTrue( is_post_type_archive( $post_type ) );
+		$this->assertSame( $layer_archive, $this->get_active_ad_layer() );
+	}
+}

--- a/tests/php/test-dfp-paths.php
+++ b/tests/php/test-dfp-paths.php
@@ -11,6 +11,16 @@ class Ad_Layers_DFP_Paths_Tests extends Ad_Layers_UnitTestCase {
 		$this->assertEquals( '/6355419/sidebar/front', $this->ad_server->get_path( 'default', 'sidebar' ) );
 	}
 
+	public function test_static_path_templates() {
+		$path = rand_str();
+		$settings = $this->ad_server_settings;
+		$settings['ad_units'][0]['path_override'] = "/{$path}";
+		$this->update_ad_server_settings( $settings );
+		$this->ad_server->get_ad_units_for_layer( $this->ad_layer );
+
+		$this->assertEquals( "/{$path}", $this->ad_server->get_path( 'default', 'sidebar' ) );
+	}
+
 	public function test_no_path_templates() {
 		$settings = $this->ad_server_settings;
 		$settings['path_templates'] = array();

--- a/tests/php/test-page-types.php
+++ b/tests/php/test-page-types.php
@@ -6,7 +6,7 @@ class Ad_Layers_Page_Types_Tests extends Ad_Layers_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		register_taxonomy( 'test-taxonomy', 'post', array( 'label' => rand_str() ) );
+		register_taxonomy( 'test-taxonomy', 'post' );
 
 		$this->editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
 
@@ -110,7 +110,7 @@ class Ad_Layers_Page_Types_Tests extends Ad_Layers_UnitTestCase {
 	public function test_cpt_without_archive_page_type() {
 		$post_type = rand_str( 20 );
 		register_post_type( $post_type, array( 'public' => true ) );
-		$cpt_id = $this->factory->post->create( array( 'post_title' => 'hello-cpt', 'post_type' => $post_type, 'label' => rand_str() ) );
+		$cpt_id = $this->factory->post->create( array( 'post_title' => 'hello-cpt', 'post_type' => $post_type ) );
 		Ad_Layers::instance()->page_types = null;
 
 		$this->go_to( get_permalink( $cpt_id ) );
@@ -121,7 +121,7 @@ class Ad_Layers_Page_Types_Tests extends Ad_Layers_UnitTestCase {
 	public function test_cpt_with_archive_page_types() {
 		$post_type = rand_str( 20 );
 		register_post_type( $post_type, array( 'public' => true, 'has_archive' => true ) );
-		$cpt_id = $this->factory->post->create( array( 'post_title' => 'hello-cpt', 'post_type' => $post_type, 'label' => rand_str() ) );
+		$cpt_id = $this->factory->post->create( array( 'post_title' => 'hello-cpt', 'post_type' => $post_type ) );
 		Ad_Layers::instance()->page_types = null;
 
 		// Singular view

--- a/tests/php/test-page-types.php
+++ b/tests/php/test-page-types.php
@@ -132,7 +132,6 @@ class Ad_Layers_Page_Types_Tests extends Ad_Layers_UnitTestCase {
 		// Archive view
 		$this->go_to( get_post_type_archive_link( $post_type ) );
 		$this->assertTrue( is_post_type_archive( $post_type ) );
-		// commented due to https://github.com/alleyinteractive/ad-layers/issues/42
-		// $this->assertSame( $post_type, Ad_Layers::instance()->get_current_page_type() );
+		$this->assertSame( 'archive::' . $post_type, Ad_Layers::instance()->get_current_page_type() );
 	}
 }


### PR DESCRIPTION
Needs to follow #43, #44. After they're merged, this PR will trim down considerably.

* Differentiates between page type matches for singular and archive post type views
* Fixes bug with static paths (if a path template didn't have a formatting tag, it returned the default)
* Fixes bug with taxonomy page type matches
* Adds full test coverage for active layer detection

This started off as a simple fix to #42, but ended up addressing several bugs uncovered via unit testing.