### PR TITLE
Allowing 0,0 width/height.

### DIFF
--- a/php/ad-servers/class-ad-layers-dfp.php
+++ b/php/ad-servers/class-ad-layers-dfp.php
@@ -472,7 +472,7 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 					$sizes = array();
 					foreach ( $ad_unit['sizes'] as $size ) {
 						// If no width or height is set, assume we added an empty size to hide the ad.
-						$unit_size = [];
+						$unit_size = array();
 						// Set the width.
 						if ( isset( $size['width'] ) ) {
 							$unit_size[] = absint($size['width']);

--- a/php/ad-servers/class-ad-layers-dfp.php
+++ b/php/ad-servers/class-ad-layers-dfp.php
@@ -471,21 +471,36 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 					// Set the sizes
 					$sizes = array();
 					foreach ( $ad_unit['sizes'] as $size ) {
-						if ( ! empty( $size['width'] ) && ! empty( $size['height'] ) ) {
-							$sizes[] = array( absint( $size['width'] ), absint( $size['height'] ) );
-
-							// If this is the default size, save it.
-							// If more than one size is accidentally marked as default, the last one will be used.
-							if ( ! empty( $size['default_size'] ) && 'default' == $size['default_size'] ) {
-								$this->default_by_unit[ $ad_unit['code'] ] = array( absint( $size['width'] ), absint( $size['height'] ) );
-							}
-
-							// If this is an oop unit, note it.
-							// If more than one size is accidentally marked as default, the last one will be used.
-							if ( ! empty( $size['out_of_page'] ) && 'oop' == $size['out_of_page'] ) {
-								$this->oop_units[] = $ad_unit['code'];
-							}
+						// If no width or height is set, assume we added an empty size to hide the ad.
+						$unit_size = [];
+						// Set the width.
+						if ( isset( $size['width'] ) ) {
+							$unit_size[] = absint($size['width']);
 						}
+						else {
+							$unit_size[] = 0;
+						}
+						// Set the height.
+						if ( isset( $size['height'] ) ) {
+							$unit_size[] = absint($size['height']);
+						}
+						else {
+							$unit_size[] = 0;
+						}
+						$sizes[] = $unit_size;
+
+						// If this is the default size, save it.
+						// If more than one size is accidentally marked as default, the last one will be used.
+						if ( ! empty( $size['default_size'] ) && 'default' == $size['default_size'] ) {
+							$this->default_by_unit[ $ad_unit['code'] ] = array( absint( $size['width'] ), absint( $size['height'] ) );
+						}
+
+						// If this is an oop unit, note it.
+						// If more than one size is accidentally marked as default, the last one will be used.
+						if ( ! empty( $size['out_of_page'] ) && 'oop' == $size['out_of_page'] ) {
+							$this->oop_units[] = $ad_unit['code'];
+						}
+
 					}
 					$sizes = apply_filters( 'ad_layers_dfp_ad_unit_sizes', $sizes, $ad_unit, $breakpoint );
 


### PR DESCRIPTION
Allow a width and height for ad sizes of 0,0. 

When dealing with responsize ads, sometimes we with to hide an ad by setting a size of 0,0 so that we can achieve ad mapping sizes such as: 
```js
var mapping1 = googletag.sizeMapping().
  addSize([0, 0], []).
  addSize([1050, 200], [1024, 120]). // Desktop
  build();
``` 

Currently, there is code the says `If the width or height is empty, ignore the ad size`. This instead treats empty `width` and `heights` as a size of `0`.