### PR TITLE
Carrying the echo var through for the short-code implementation.

### DIFF
--- a/php/ad-servers/class-ad-layers-ad-server.php
+++ b/php/ad-servers/class-ad-layers-ad-server.php
@@ -221,9 +221,9 @@ if ( ! class_exists( 'Ad_Layers_Ad_Server' ) ) :
 		 *
 		 * @access public
 		 */
-		public function get_ad_unit( $ad_unit ) {
+		public function get_ad_unit( $ad_unit, $echo = true ) {
 			if ( ! empty( $this->ad_server ) ) {
-				$this->ad_server->get_ad_unit( $ad_unit );
+				$this->ad_server->get_ad_unit( $ad_unit, $echo );
 			}
 		}
 

--- a/php/class-ad-layers-shortcodes.php
+++ b/php/class-ad-layers-shortcodes.php
@@ -38,7 +38,10 @@ if ( ! class_exists( 'Ad_Layers_Shortcodes' ) ) :
 			// Attempt to display the specified ad unit.
 			// This will just do nothing if the unit is invalid
 			// or doesn't exist in the current ad layer.
-			return Ad_Layers_Ad_Server::instance()->get_ad_unit( $atts['unit'] );
+			// Since the WP shortcode pattern is running and trying to replace
+			// our shortcode, we need to return the ad and what to replace there,
+			// so we set the echo value to false for get_ad_unit.
+			return Ad_Layers_Ad_Server::instance()->get_ad_unit( $atts['unit'], false );
 		}
 	}
 


### PR DESCRIPTION
When the shortcode pattern matcher runs, the ad code is just echoed out. We want the value returned so that the short-code can be replaced in the exact location we place it. 

There is a value in the implementation of the `DFP` server, however there is not a variable on the parent items ( generic server, and when the function is called from the `class-ad-layers-shortcodes.php` file ).  

All this does is in the short-code call in `class-ad-layers-shortcodes.php`, we set the echo param to `false`, and carry it through to the `get_ad_unit` call for the instance called. 