### PR TITLE
Adding the option for a universal path template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,13 @@ matrix:
   fast_finish: true
 
 before_script:
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - |
+    if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
+      composer global require "phpunit/phpunit=5.7.*"
+    else
+      composer global require "phpunit/phpunit=4.8.*"
+    fi
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
       bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION

--- a/php/ad-servers/class-ad-layers-dfp.php
+++ b/php/ad-servers/class-ad-layers-dfp.php
@@ -344,7 +344,7 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 								'label' => __( 'Page Type', 'ad-layers' ),
 								'options' => array_merge(
 									array(
-										'all' => __( 'All Pages', 'ad-layers' )
+										'all' => __( 'All Pages', 'ad-layers' ),
 									),
 									Ad_Layers::instance()->get_page_types()
 								),

--- a/php/ad-servers/class-ad-layers-dfp.php
+++ b/php/ad-servers/class-ad-layers-dfp.php
@@ -342,7 +342,12 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 						'page_type' => new Fieldmanager_Select(
 							array(
 								'label' => __( 'Page Type', 'ad-layers' ),
-								'options' => Ad_Layers::instance()->get_page_types(),
+								'options' => array_merge(
+									array(
+										'all' => __( 'All Pages', 'ad-layers' )
+									),
+									Ad_Layers::instance()->get_page_types()
+								),
 							)
 						),
 					),
@@ -880,6 +885,10 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 					// If we have a match, use that template
 					if ( ! empty( $path_templates_by_page_type[ $page_type ] ) ) {
 						$path_template = $path_templates_by_page_type[ $page_type ];
+					} else if ( empty( $path_templates_by_page_type[ $page_type ] )
+						&& ! empty( $path_templates_by_page_type['all'] ) ) {
+						// If the path template is still empty, check if a global template exists for all pages
+						$path_template = $path_templates_by_page_type['all'];
 					}
 				}
 			}


### PR DESCRIPTION
Smaller sites might just use a single template for the entire site. There wasn't a good way to set this globally prior to now, only at the unit or layer level. 