### PR TITLE
Adds the Post ID as an option for custom targeting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ All taxonomies that are associated with Ad Layers (category and post_tag by defa
 Click "Add custom targeting" to choose one or more DFP custom targeting variables to add to the DFP request produced by this ad layer. The value can be:
 - The term(s) associated with the page. This will only be populated on taxonomy archives or single posts. The taxonomies associated with Ad Layers are available for selection.
 - The post type of the page. This will only be populated on post type archives or single posts.
+- The post id of the post or page. This will only be populated on single posts and pages.
 - The author. This will only be populated on author archives or single posts.
 - Other. This can be any free-form text value and will be static anywhere the ad layer is displayed.
 

--- a/php/ad-servers/class-ad-layers-ad-server.php
+++ b/php/ad-servers/class-ad-layers-ad-server.php
@@ -403,6 +403,7 @@ if ( ! class_exists( 'Ad_Layers_Ad_Server' ) ) :
 			// Add additional options
 			$options = array_merge( $options, array(
 				'post_type' => __( 'Post Type', 'ad-layers' ),
+				'post_id' => __( 'Post ID', 'ad-layers' ),
 				'author' => __( 'Author', 'ad-layers' ),
 				'other' => __( 'Other', 'ad-layers' ),
 			) );

--- a/php/ad-servers/class-ad-layers-dfp.php
+++ b/php/ad-servers/class-ad-layers-dfp.php
@@ -765,6 +765,11 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 						$targeting_value = $queried_object->name;
 					}
 					break;
+				case 'post_id':
+					if ( is_singular() ) {
+						$targeting_value = (string) get_the_ID();
+					}
+					break;
 				default:
 					if ( taxonomy_exists( $source ) ) {
 						if ( is_singular() ) {


### PR DESCRIPTION
Targeting values must be strings or an array of strings (which is why the value in this PR is cast as a string).
See: https://developers.google.com/doubleclick-gpt/reference#googletag.PassbackSlot_setTargeting

Resolves #62 