### PR TITLE
Don't escape the widget's output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ branches:
 
 matrix:
   include:
-    - php: 5.3
-      env: WP_VERSION=4.4
-    - php: 5.3
-      env: WP_VERSION=latest
     - php: 5.6
       env: WP_VERSION=latest
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ branches:
 
 matrix:
   include:
+    - php: 5.3
+      env: WP_VERSION=4.4
+      dist: precise
+    - php: 5.3
+      env: WP_VERSION=latest
+      dist: precise
     - php: 5.6
       env: WP_VERSION=latest
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,12 @@ matrix:
     - php: 7.0
       env: WP_VERSION=latest
     - php: 5.6
+      env: WP_VERSION=latest
+    - php: 7.0
       env: WP_VERSION=nightly
-    - php: 5.6
+    - php: 7.0
       env: WP_TRAVISCI=phpcs
+
   fast_finish: true
 
 before_script:

--- a/php/class-ad-layers-widget.php
+++ b/php/class-ad-layers-widget.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'Ad_Layers_Widget' ) ) :
 			}
 
 			// Display the ad unit
-			echo $args['before_widget'] . $ad_unit_html . $args['after_widget'];
+			echo $args['before_widget'] . $ad_unit_html . $args['after_widget']; // WPCS: XSS okay.
 		}
 
 		/**

--- a/php/class-ad-layers-widget.php
+++ b/php/class-ad-layers-widget.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'Ad_Layers_Widget' ) ) :
 			}
 
 			// Display the ad unit
-			echo wp_kses_post( $args['before_widget'] . $ad_unit_html . $args['after_widget'] );
+			echo $args['before_widget'] . $ad_unit_html . $args['after_widget'];
 		}
 
 		/**


### PR DESCRIPTION
Don't escape the widget's output when using `get_ad_unit()`. It is used elsewhere un-escaped. When running `wp_kses_post()` on it, it removes the script tag leaving the unit un-rendered.