### PR TITLE
Try to set a default ad layer if no ad layer has been defined.

### DIFF
--- a/php/class-ad-layers.php
+++ b/php/class-ad-layers.php
@@ -330,6 +330,19 @@ if ( ! class_exists( 'Ad_Layers' ) ) :
 					break;
 				}
 			}
+
+			// If no ad layer has been defined.
+			// Try to set a default ad layer.
+			if ( empty( $this->ad_layer ) ) {
+				foreach ( $this->ad_layers as $ad_layer ) {
+					$page_types = get_post_meta( $ad_layer['post_id'], 'ad_layer_page_types', true );
+
+					if ( in_array( 'default', $page_types ) ) {
+						$this->ad_layer = $ad_layer;
+						break;
+					}
+				}
+			}
 		}
 
 		/**


### PR DESCRIPTION
This PR is to set a default adlayer if no adlayer has been defined in Ad_Layers set_active_ad_layer. This would allow a default layer to be used on a variety of pages without having to set granular layers such as the author or 404 pages.