### PR TITLE
disallow 0x0 unit size

### DIFF
--- a/php/ad-servers/class-ad-layers-dfp.php
+++ b/php/ad-servers/class-ad-layers-dfp.php
@@ -305,9 +305,7 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 						'group_is_empty' => function( $values ) {
 							if ( isset( $values['width'], $values['height'] ) ) {
 								// Disallow 0px X 0px for an ad unit size. This sometimes leads to an "unremovable" field in the group.
-								if ( empty( $values['width'] ) && empty( $values['height'] ) ) {
-									return true;
-								}
+								return ( empty( $values['width'] ) && empty( $values['height'] ) );
 							}
 
 							// Default to saving the field.


### PR DESCRIPTION
The current lack of `group_is_empty` allows for cases where ad-layers will save an ad unit size as 0x0. This size group then becomes impossible to remove. This PR ensures that any sizes groups that have a 0x0 ad unit will not be saved.

![Screen Shot 568](https://user-images.githubusercontent.com/1018205/67962241-3f4a0e80-fbd3-11e9-88cd-113593669d8c.png)


@mboynes / @bcampeau: For backwards-compat reasons, is there any use-case for an ad unit being 0x0?