### PR TITLE
BASS-740: Set up video companion ads #2

### DIFF
--- a/entries/ad-layers-dfp/index.js
+++ b/entries/ad-layers-dfp/index.js
@@ -79,7 +79,6 @@ import './style.scss';
           dfpAdUnits[slotName].addService(googletag.companionAds()).addService(googletag.pubads());
           googletag.companionAds().setRefreshUnfilledSlots(true);
           googletag.pubads().enableVideoAds();
-          googletag.pubads().disableInitialLoad();
         } else {
           dfpAdUnits[slotName].addService(googletag.pubads());
         }


### PR DESCRIPTION
(adds onto https://github.com/alleyinteractive/ad-layers/pull/91)
- Removes unneeded `googletag.pubads().disableInitialLoad()`