### PR TITLE
Fix: Duplicates and Orphans

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
     "phpcbf": "phpcbf .",
     "phpcs": "phpcs . --runtime-set text_domain ad-layers --runtime-set prefixes ad_layers,_ai,ai_",
     "phpunit": "phpunit"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/inc/class-ad-layers-admin.php
+++ b/inc/class-ad-layers-admin.php
@@ -105,7 +105,7 @@ if ( ! class_exists( 'Ad_Layers\Ad_Layers_Admin' ) ) :
 					/* translators: macro title. */
 					'label_macro'    => [ __( '%s', 'ad-layers' ), 'title' ], // phpcs:ignore WordPress.WP.I18n.NoEmptyStrings
 					'children'       => [
-						'post_id' => new Fieldmanager_Hidden(),
+						'post_id' => new Fieldmanager_Hidden( [ 'sanitize' => 'intval' ] ),
 						'title'   => new Fieldmanager_Textfield(
 							[
 								'label'      => __( 'Title', 'ad-layers' ),

--- a/inc/class-ad-layers-post-type.php
+++ b/inc/class-ad-layers-post-type.php
@@ -289,7 +289,7 @@ if ( ! class_exists( 'Ad_Layers_Post_Type' ) ) :
 
 				// Otherwise, find and update the layer.
 				foreach ( $ad_layers as $i => $layer ) {
-					if ( $layer['post_id'] === $post_id ) {
+					if ( (int) $layer['post_id'] === (int) $post_id ) {
 						$position = $i;
 						break;
 					}
@@ -321,7 +321,7 @@ if ( ! class_exists( 'Ad_Layers_Post_Type' ) ) :
 
 			// Find and remove the layer.
 			foreach ( $ad_layers as $i => $layer ) {
-				if ( $layer['post_id'] === $post_id ) {
+				if ( (int) $layer['post_id'] === (int) $post_id ) {
 					unset( $ad_layers[ $i ] );
 					break;
 				}

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Ad Layers Tests: Admin tests
+ *
+ * @package Ad_Layers
+ * @subpackage Tests
+ */
+
+use Ad_Layers\Ad_Layers;
+
+/**
+ * Test_Active_Layer Class.
+ */
+class Test_Admin extends Ad_Layers_TestCase {
+	/**
+	 * Ensures that when layers are created, renamed, and removed, they appear
+	 * correctly in layer priority, not creating duplicates or orphans.
+	 */
+	public function test_layer_priority_sync() {
+		// Ensure that we start out with only one item in layer priority (from parent setUp).
+		$layer_priority = get_option( 'ad_layers' );
+		$this->assertEquals( 1, count( $layer_priority ) );
+		$layer_1_id = $layer_priority[0]['post_id'];
+
+		// Ensure new layers show up in layer priority.
+		$layer_2        = self::factory()->post->create_and_get( [ 'post_type' => 'ad-layer' ] );
+		$layer_priority = get_option( 'ad_layers' );
+		$this->assertEquals( 2, count( $layer_priority ) );
+		$this->assertEquals( $layer_2->ID, $layer_priority[1]['post_id'] );
+
+		// Ensure that renaming a layer does not create duplicates in layer priority.
+		$layer_2->post_title = 'New Layer Title';
+		wp_update_post( $layer_2 );
+		$layer_priority = get_option( 'ad_layers' );
+		$this->assertEquals( 2, count( $layer_priority ) );
+		$this->assertEquals( $layer_2->ID, $layer_priority[1]['post_id'] );
+
+		// Ensure that removing a layer does not result in orphans in layer priority.
+		wp_delete_post( $layer_2->ID );
+		$layer_priority = get_option( 'ad_layers' );
+		$this->assertEquals( 1, count( $layer_priority ) );
+		$this->assertEquals( $layer_1_id, $layer_priority[0]['post_id'] );
+
+		// Add another layer so it gets automatically added to layer priority.
+		$layer_3        = self::factory()->post->create_and_get( [ 'post_type' => 'ad-layer' ] );
+		$layer_priority = get_option( 'ad_layers' );
+		$this->assertEquals( 2, count( $layer_priority ) );
+		$this->assertEquals( $layer_3->ID, $layer_priority[1]['post_id'] );
+
+		// Simulate the (legacy) behavior of layer priority changes resulting in post IDs being cast to strings.
+		$layer_priority[1]['post_id'] = (string) $layer_3->ID;
+		update_option( 'ad_layers', $layer_priority );
+
+		// Ensure that renaming a layer does not create duplicates in layer priority.
+		$layer_3->post_title = 'New Layer Title 2';
+		wp_update_post( $layer_3 );
+		$layer_priority = get_option( 'ad_layers' );
+		$this->assertEquals( 2, count( $layer_priority ) );
+		$this->assertEquals( $layer_3->ID, (int) $layer_priority[1]['post_id'] );
+
+		// Ensure that removing a layer does not result in orphans in layer priority.
+		wp_delete_post( $layer_3->ID );
+		$layer_priority = get_option( 'ad_layers' );
+		$this->assertEquals( 1, count( $layer_priority ) );
+		$this->assertEquals( $layer_1_id, (int) $layer_priority[0]['post_id'] );
+	}
+}


### PR DESCRIPTION
* Fixes a bug whereby updating ad layers results in duplicate layers being added to layer priority
* Fixes a bug whereby deleting ad layers results in orphan layers in layer priority
* Adds a unit test to verify the fix
* Updates the post ID Fieldmanager field definition so it is run through an `intval` sanitizer to ensure it saves the post ID as an integer in the option when layer priority is adjusted