### PR TITLE
Fix for styles on the create/edit Ad Layer screen

### DIFF
--- a/entries/ad-layers-admin/style.scss
+++ b/entries/ad-layers-admin/style.scss
@@ -15,3 +15,18 @@
     white-space: pre;
   }
 }
+
+.fm-ad_layer_ad_units {
+  padding-left: 1em;
+  position: relative;
+}
+
+.fm-ad_layer_ad_units-wrapper {
+  .fm-group-label-wrapper {
+    border: none;
+
+    &:hover {
+      border: none;
+    }
+  }
+}

--- a/inc/class-ad-layers-admin.php
+++ b/inc/class-ad-layers-admin.php
@@ -76,7 +76,7 @@ if ( ! class_exists( 'Ad_Layers\Ad_Layers_Admin' ) ) :
 		public function enqueue_scripts() {
 			// Load the CSS to customize some Fieldmanager features.
 			$current_screen = get_current_screen();
-			if ( 'edit-ad-layer' === $current_screen->id || 'ad-layer_page_ad_layers' === $current_screen->base ) {
+			if ( 'ad-layer' === $current_screen->id || 'edit-ad-layer' === $current_screen->id || 'ad-layer_page_ad_layers' === $current_screen->base ) {
 				wp_enqueue_script(
 					'ad-layers-admin',
 					get_ad_layers_path( 'adLayersAdmin.js' ),


### PR DESCRIPTION
* Fixes a display bug with draggable items for ad slots on the create/edit ad layer screen that currently makes it impossible to remove a layer from the list and causes issues with text being overlapped with borders.