### PR TITLE
Fix Correlator Sync Issue

### DIFF
--- a/entries/ad-layers-dfp/index.js
+++ b/entries/ad-layers-dfp/index.js
@@ -110,7 +110,9 @@ import './style.scss';
           dfpAdUnits[slotName].addService(googletag.pubads());
         }
         googletag.display(divId);
-        googletag.pubads().refresh([dfpAdUnits[slotName]]);
+        if (companion) {
+          this.refresh(slotName);
+        }
       });
     }
   };

--- a/inc/ad-servers/class-ad-layers-dfp.php
+++ b/inc/ad-servers/class-ad-layers-dfp.php
@@ -243,7 +243,7 @@ if ( ! class_exists( 'Ad_Layers_DFP' ) ) :
 				gads.type = 'text/javascript';
 				var useSSL = 'https:' === document.location.protocol;
 				gads.src = (useSSL ? 'https:' : 'http:') +
-				'//www.googletagservices.com/tag/js/gpt.js';
+				'//securepubads.g.doubleclick.net/tag/js/gpt.js';
 				var node = document.getElementsByTagName('script')[0];
 				node.parentNode.insertBefore(gads, node);
 				})();


### PR DESCRIPTION
- Fixes an issue where correlator values are different for each ad request because `.refresh()` is being called for all ads added via the `buildAd` method.
- Updates the URL to `gpt.js` to use Google's current recommendation from the docs.