### PR TITLE
BASS-1029 Move scripts to header

### DIFF
--- a/inc/class-ad-layers-admin.php
+++ b/inc/class-ad-layers-admin.php
@@ -82,7 +82,7 @@ if ( ! class_exists( 'Ad_Layers\Ad_Layers_Admin' ) ) :
 					get_ad_layers_path( 'adLayersAdmin.js' ),
 					get_ad_layers_dependencies( 'adLayersAdmin.php' ),
 					get_ad_layers_hash( 'adLayersAdmin.js' ),
-					true
+					false
 				);
 			}
 		}

--- a/inc/class-ad-server.php
+++ b/inc/class-ad-server.php
@@ -166,7 +166,7 @@ if ( ! class_exists( 'Ad_Layers\Ad_Servers\Ad_Server' ) ) :
 				get_ad_layers_path( 'adLayers.js' ),
 				$dependencies,
 				get_ad_layers_hash( 'adLayers.js' ),
-				true
+				false
 			);
 
 			// Localize the base API with the class name.


### PR DESCRIPTION
#### What does this PR do?

1. Flips `$in_footer` booleans in `wp_enqueue_script` to false so scripts enqueue in the header.